### PR TITLE
Planning599hadolint

### DIFF
--- a/src/pages/guides/continuous-integration-tekton/index.mdx
+++ b/src/pages/guides/continuous-integration-tekton/index.mdx
@@ -53,6 +53,7 @@ The following gives a description of each `Task` that is commonly used in a
 - **Setup** clones the code into the pipeline
 - **Build** runs the build commands for the code
 - **Test**	validates the unit tests for the code
+- **Lint** (*optional*) Lints the Dockerfile according to Docker best practices using hadolint
 - **Publish pacts**	(*optional*) publishes any pact contracts that have been defined
 - **Verify pact** (*optional*) verifies the pact contracts
 - **Sonar scan** (*optional*) runs a sonar code scan of the source code and publishes the results to SonarQube

--- a/src/pages/guides/continuous-integration-tekton/index.mdx
+++ b/src/pages/guides/continuous-integration-tekton/index.mdx
@@ -53,7 +53,7 @@ The following gives a description of each `Task` that is commonly used in a
 - **Setup** clones the code into the pipeline
 - **Build** runs the build commands for the code
 - **Test**	validates the unit tests for the code
-- **Lint** (*optional*) Lints the Dockerfile according to Docker best practices using hadolint
+- **Lint** (*optional*) Lints the Dockerfile according to Docker best practices using [hadolint](https://hub.docker.com/r/hadolint/hadolint)
 - **Publish pacts**	(*optional*) publishes any pact contracts that have been defined
 - **Verify pact** (*optional*) verifies the pact contracts
 - **Sonar scan** (*optional*) runs a sonar code scan of the source code and publishes the results to SonarQube


### PR DESCRIPTION
Lint step is added to 'Continuous Integration with Tekton' page, pointing the user to hadolint docker page for configuration. I can also incorporate FAQ section, however I am not sure which page/section I can add. Could you please advise, if you need an FAQ section for hadolint?