### PR TITLE
Update cd.md

### DIFF
--- a/docs/resources/workshop/cd.md
+++ b/docs/resources/workshop/cd.md
@@ -28,7 +28,8 @@ Promote an Application using CD with GitOps and ArgoCD
     ```
 
 1. Verify Application is deployed in **QA**
-    - Select ArgoCD from the Console Link and login using OpenShift login
+    - Get ArgoCD's `admin` password by running `oc extract secrets/openshift-gitops-cluster --keys=admin.password -n openshift-gitops --to=-`  
+    - Select ArgoCD from the Console Link and login using `admin` and the password you just retrieved
     - Filter Applications by name `${TOOLKIT_PROJECT}-qa` (ie project01-qa)
     - Select the application `master-qa-${TOOLKIT_PROJECT}-app` (ie master-qa-project01-app)
         ![Argo CD App](images/argo-app.jpg)
@@ -73,7 +74,8 @@ Promote an Application using CD with GitOps and ArgoCD
     ```
 
 1. Verify Application is deployed in **STAGING**
-    - Select ArgoCD from the Console Link and login using OpenShift login
+    - Get ArgoCD's `admin` password by running `oc extract secrets/openshift-gitops-cluster --keys=admin.password -n openshift-gitops --to=-`  
+    - Select ArgoCD from the Console Link and login using `admin` and the password you just retrieved
     - Filter Applications by namespace `${TOOLKIT_PROJECT}-staging` (ie project01-staging)
     - It might take a couple minutes for the application to show up
     - Select the application `master-staging-${TOOLKIT_PROJECT}-app` (ie master-staging-project01-app)

--- a/docs/resources/workshop/cd.md
+++ b/docs/resources/workshop/cd.md
@@ -28,7 +28,7 @@ Promote an Application using CD with GitOps and ArgoCD
     ```
 
 1. Verify Application is deployed in **QA**
-    - Get ArgoCD's `admin` password by running `oc extract secrets/openshift-gitops-cluster --keys=admin.password -n openshift-gitops --to=-`  
+    - Get ArgoCD's `admin` password by running `oc credentials`  
     - Select ArgoCD from the Console Link and login using `admin` and the password you just retrieved
     - Filter Applications by name `${TOOLKIT_PROJECT}-qa` (ie project01-qa)
     - Select the application `master-qa-${TOOLKIT_PROJECT}-app` (ie master-qa-project01-app)
@@ -74,7 +74,7 @@ Promote an Application using CD with GitOps and ArgoCD
     ```
 
 1. Verify Application is deployed in **STAGING**
-    - Get ArgoCD's `admin` password by running `oc extract secrets/openshift-gitops-cluster --keys=admin.password -n openshift-gitops --to=-`  
+    - Get ArgoCD's `admin` password by running `oc credentials`  
     - Select ArgoCD from the Console Link and login using `admin` and the password you just retrieved
     - Filter Applications by namespace `${TOOLKIT_PROJECT}-staging` (ie project01-staging)
     - It might take a couple minutes for the application to show up


### PR DESCRIPTION
OpenShift Operator-deployed ArgoCD does no longer feature a "Log in with OpenShift" button. Here are instructions on how to retrieve the `admin` password and how to use it to log in to ArgoCD.