### PR TITLE
update student links in CI document and fix youtube links

### DIFF
--- a/docs/learning/fast-cd.md
+++ b/docs/learning/fast-cd.md
@@ -47,7 +47,7 @@ Argo CD uses a Git repo to express the desired state of the Kubernetes environme
 !!!Note
     There is nothing special about a git repository used for git-ops. All that is required at a minimum is a hosted git repository that is accessible from by the Argo CD instance.  The [Argo CD Starter Kit](https://github.com/IBM/template-argocd-gitops) used in the following steps is optional and provides some application templates to help simplify some configuration activities.
 
-[!["GitOps with ArgoCD"](http://img.youtube.com/vi/plK2C-efwW8/0.jpg)](https://youtu.be/plK2C-efwW8 "GitOps with ArgoCD"){: target=_blank }
+<iframe width="100%" height="500" src="https://www.youtube-nocookie.com/embed/plK2C-efwW8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 1. Create a new repo from the [Argo CD Starter Kit](https://github.com/IBM/template-argocd-gitops) `https://github.com/IBM/template-argocd-gitops/generate`.  
 

--- a/docs/learning/fast-ci.md
+++ b/docs/learning/fast-ci.md
@@ -9,7 +9,7 @@
 
 The environment supports end-to-end development and deployment of an application. The instructions below will show you how to do it.
 
-[!["Deploying an App with Tekton and the IGC command line tool"](http://img.youtube.com/vi/czYQfvPTa7Y/0.jpg)](https://youtu.be/czYQfvPTa7Y "Deploying an App with Tekton and the IGC command line tool"){: target=_blank }
+<iframe width="100%" height="500" src="https://www.youtube-nocookie.com/embed/czYQfvPTa7Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 You can create a new app using one of the [Starter Kits](../reference/starter-kit/starter-kit.md){: target=_blank }. These have been created to include all the key components, configuration, and frameworks to get you started on creating the code you need for your solutions. The approach for getting started is exactly the same for an environment based on **Kubernetes** or **Red Hat OpenShift**.
 

--- a/docs/reference/tools/argocd.md
+++ b/docs/reference/tools/argocd.md
@@ -43,7 +43,8 @@ Argo CD uses a Git repo to express the desired state of the Kubernetes environme
 !!!Note
     There is nothing special about a git repository used for git-ops. All that is required at a minimum is a hosted git repository that is accessible from by the Argo CD instance.  The [Argo CD template](https://github.com/IBM/template-argocd-gitops){: target=_blank} used in the following steps is optional and provides some application templates to help simplify some configuration activities.
 
-[![Gitops with ArgoCD](http://img.youtube.com/vi/plK2C-efwW8/0.jpg)](https://youtu.be/plK2C-efwW8 "Gitops with ArgoCD"){: target="_blank"}
+<iframe width="100%" height="500" src="https://www.youtube-nocookie.com/embed/plK2C-efwW8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 
 1. Create a new repo from the [Argo CD template](https://github.com/IBM/template-argocd-gitops){: target=_blank}.  
 

--- a/docs/reference/tools/tekton.md
+++ b/docs/reference/tools/tekton.md
@@ -16,7 +16,7 @@ Tekton is a new emerging CI tool that has been built to support Kubernetes and O
 
 ### Tekton 101
 
-[![What is Tekton](http://img.youtube.com/vi/TWxKD9dLpmk/0.jpg)](https://youtu.be/TWxKD9dLpmk "What is Tekton"){: target="_blank"}
+<iframe width="100%" height="500" src="https://www.youtube-nocookie.com/embed/TWxKD9dLpmk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Tekton provides open-source components to help you standardize your CI/CD tooling and processes across vendors, languages, and deployment environments. Industry specifications around pipelines, releases, workflows, and other CI/CD components available with Tekton will work well with existing CI/CD tools such as Jenkins, Jenkins X, Skaffold, and Knative, among others.
 

--- a/docs/resources/workshop/ci.md
+++ b/docs/resources/workshop/ci.md
@@ -6,7 +6,7 @@
 
 1. Prerequisites
     - The instructor should [Setup Workshop Environment](setup.md)
-    - The student should [Setup CLI and Terminal Shell](setup.md#4-optional-auto-configure-terminal-shell)
+    - The student should [Setup the CLI locally](../../learning/dev-setup.md#install-the-cloud-native-toolkit-command-line-interface-cli) or [Setup the Terminal Shell](terminal.md)
 
 1. Instructor will provide the following info:
     - OpenShift Console URL (OCP_CONSOLE_URL)


### PR DESCRIPTION
Fix students links in CI page to install CLI and terminal.
Also fixed the YouTube videos links.

fixes /planning#784

Signed-off-by: Larry Steck <lsteck@us.ibm.com>